### PR TITLE
page number doesn't work for manually adding

### DIFF
--- a/src/query.php
+++ b/src/query.php
@@ -131,14 +131,18 @@ function km_dp_date_pagination_posts_clauses( $clauses, $query ) {
 	// Add all dates to the query object.
 	$query->set( 'date_pagination_dates', $all_dates );
 
-	// Get the current page.
-	if ( get_query_var( 'paged' ) ) {
-		$paged = get_query_var( 'paged' );
-	} elseif ( get_query_var( 'page' ) ) {
-		$paged = get_query_var( 'page' );
-	} else {
-		$paged = 1;
-	}
+    // Get the current page.
+    if ( !empty($query->query['paged']) && ( $query->query['paged'] > 0 ) ) {
+        $paged = $query->query['paged'];
+    } else {
+        if ( get_query_var( 'paged' ) ) {
+            $paged = get_query_var( 'paged' );
+        } elseif ( get_query_var( 'page' ) ) {
+            $paged = get_query_var( 'page' );
+        } else {
+            $paged = 1;
+        }
+    }
 
 	// Don't return posts if a paginated page is over the max_num_pages.
 	if ( $paged > $page_count ) {


### PR DESCRIPTION
                    $args = [
                        'post_type' => 'post',
                        'date_pagination_type' => 'daily',
                        'paged' => $paged, // it would work coz' it depends on $paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
                    ];


It won't work if I want to add 'paged' => 2 manually. Why we need to add manually because we would set pagination through ajax call like below

                    $args = [
                        'post_type' => 'post',
                        'date_pagination_type' => 'daily',
                        'paged' => 2, // We would need to add page number manually when using ajax call
                    ];

My suggestion changes was to work on both ways.